### PR TITLE
Add historical request functionality

### DIFF
--- a/rates.go
+++ b/rates.go
@@ -3,10 +3,12 @@ package dinero
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 const (
-	latestAPIPath = "latest.json"
+	latestAPIPath     = "latest.json"
+	historicalAPIPath = "historical/%s.json"
 )
 
 // RatesService handles rate request/responses.
@@ -97,6 +99,26 @@ func (s *RatesService) Update(base string) error {
 	s.client.Cache.Store(latest)
 
 	return nil
+}
+
+// GetHistoricalList will fetch all rates for the date for the base currency
+func (s *RatesService) GetHistoricalList(date string) (*RateResponse, error) {
+	if _, err := time.Parse("2006-01-02", date); err != nil {
+		return nil, err
+	}
+	apiPath := fmt.Sprintf(historicalAPIPath, date)
+	request, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("%s?base=%s", apiPath, s.baseCurrency),
+		nil)
+	if err != nil {
+		return nil, err
+	}
+	response := &RateResponse{}
+	if _, err := s.client.Do(request, response); err != nil {
+		return nil, err
+	}
+	return response, nil
 }
 
 // GetBaseCurrency will return the baseCurrency.

--- a/rates_test.go
+++ b/rates_test.go
@@ -9,6 +9,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	ISO8601DateLayout = "2006-01-02"
+)
+
 // TestListRates will test updating our local store of forex rates from the OXR API.
 func TestListRates(t *testing.T) {
 	// Register the test.
@@ -21,6 +25,29 @@ func TestListRates(t *testing.T) {
 	response, err := client.Rates.List()
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Rates.List(): %s", err.Error())
+	}
+
+	if response.Base != "AUD" {
+		t.Fatalf("Unexpected base oxr rate: %s. Expecting `AUD`.", err.Error())
+	}
+
+	if response.Rates == nil {
+		t.Fatalf("Unexpected length of rates: %s.", err.Error())
+	}
+}
+
+func TestGetHistoricalListRates(t *testing.T) {
+	// Register the test.
+	RegisterTestingT(t)
+
+	// Init dinero client.
+	client := NewClient(os.Getenv("OPEN_EXCHANGE_APP_ID"), "AUD", 1*time.Minute)
+
+	// Get forex rates for today
+	date := time.Now().Format(ISO8601DateLayout)
+	response, err := client.Rates.GetHistoricalList(date)
+	if err != nil {
+		t.Fatalf("Unexpected error running client.Rates.GetHistoricalList(): %s", err.Error())
 	}
 
 	if response.Base != "AUD" {


### PR DESCRIPTION
I've added the possibility to fetch currencies for some date (historical API of OpenExchangeRates). It's a PoC. Problems to solve:
1. do we want to cache it using the same cache object from the client or create another one? In both cases, we will cache `RateResponse` struct  as value and `date` as of key
2. I haven't move it out from Rates Service because it's pretty similar as for me. WDYT?