### PR TITLE
allow not setting base currency

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -2,7 +2,7 @@ package dinero
 
 import (
 	"encoding/json"
-	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,14 +12,17 @@ import (
 // TestCache will test that our in-memory cache of forex results is working.
 func TestCache(t *testing.T) {
 	// Register the test.
-	RegisterTestingT(t)
+	NewWithT(t)
 
 	// Init dinero client.
-	client := NewClient(os.Getenv("OPEN_EXCHANGE_APP_ID"), "AUD", 1*time.Minute)
+	client := NewClient(appID, "AUD", 1*time.Minute)
 
 	// Get latest forex rates.
 	response1, err := client.Rates.List()
 	if err != nil {
+		if strings.HasPrefix(err.Error(), setBaseNotAllowedResponsePrefix) {
+			t.Skipf("skipping test, unsuitable app ID: %s", err)
+		}
 		t.Fatalf("Unexpected error running client.Rates.List(): %s", err.Error())
 	}
 

--- a/dinero.go
+++ b/dinero.go
@@ -65,10 +65,12 @@ func NewClient(appID, baseCurrency string, expiry time.Duration) *Client {
 
 // NewRequest creates an authenticated API request. A relative URL can be provided in urlPath,
 // which will be resolved to the BackendURL of the Client.
-func (c *Client) NewRequest(method, urlPath string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(method, urlPath string, params url.Values, body interface{}) (*http.Request, error) {
+	// make sure rendered URL is correct whether we have other params than app_id or not
+	params.Set("app_id", c.AppID)
 	// Parse our URL.
 	rel, err := url.Parse(
-		fmt.Sprintf("/api/%s&app_id=%s", urlPath, c.AppID),
+		fmt.Sprintf("/api/%s?%s", urlPath, params.Encode()),
 	)
 	if err != nil {
 		return nil, err

--- a/dinero_test.go
+++ b/dinero_test.go
@@ -1,0 +1,42 @@
+package dinero
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewRequest(t *testing.T) {
+	// Register the test.
+	NewWithT(t)
+
+	// Init dinero client.
+	client := NewClient("12345", "", 1*time.Minute)
+
+	var tests = []struct {
+		params      url.Values
+		expectedURL string
+	}{
+		{
+			params:      url.Values{},
+			expectedURL: "https://openexchangerates.org/api/latest.json?app_id=12345",
+		},
+		{
+			params:      url.Values{"base": []string{"AUD"}},
+			expectedURL: "https://openexchangerates.org/api/latest.json?app_id=12345&base=AUD",
+		},
+	}
+
+	for _, test := range tests {
+		req, err := client.NewRequest("GET", "latest.json", test.params, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual := req.URL.String()
+		if actual != test.expectedURL {
+			t.Errorf("expected %s, got %s", test.expectedURL, actual)
+		}
+	}
+}

--- a/rates_test.go
+++ b/rates_test.go
@@ -3,47 +3,106 @@ package dinero
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 )
 
-// TestListRates will test updating our local store of forex rates from the OXR API.
-func TestListRates(t *testing.T) {
+const (
+	// Default currency returned by API calls that do not set a base currency.
+	defaultCurrency = "USD"
+	// > 403 Changing the API `base` currency is available for Developer, Enterprise and Unlimited plan clients.
+	setBaseNotAllowedResponsePrefix = "403"
+)
+
+var appID = os.Getenv("OPEN_EXCHANGE_APP_ID")
+
+// TestListRatesDefaultCurrency will test updating our local store of forex rates from the OXR API expecting rates for defaultCurrency.
+func TestListRatesDefaultCurrency(t *testing.T) {
 	// Register the test.
-	RegisterTestingT(t)
+	NewWithT(t)
 
 	// Init dinero client.
-	client := NewClient(os.Getenv("OPEN_EXCHANGE_APP_ID"), "AUD", 1*time.Minute)
+	client := NewClient(appID, "", 1*time.Minute)
 
 	// Get latest forex rates.
 	response, err := client.Rates.List()
 	if err != nil {
-		t.Fatalf("Unexpected error running client.Rates.List(): %s", err.Error())
+		t.Fatalf("Unexpected error running client.Rates.List(): %s", err)
 	}
 
-	if response.Base != "AUD" {
-		t.Fatalf("Unexpected base oxr rate: %s. Expecting `AUD`.", err.Error())
+	if response.Base != defaultCurrency {
+		t.Fatalf("Unexpected base oxr rate: Expecting `%s`.", defaultCurrency)
 	}
 
 	if response.Rates == nil {
-		t.Fatalf("Unexpected length of rates: %s.", err.Error())
+		t.Fatal("Unexpected nil length of rates")
+	}
+}
+
+// TestGetRateDefaultCurrency will test pulling a single rate for defaultCurrency.
+func TestGetRateDefaultCurrency(t *testing.T) {
+	// Register the test.
+	NewWithT(t)
+
+	// Init dinero client.
+	client := NewClient(appID, "", 1*time.Minute)
+
+	// Get latest forex rates for NZD (using defaultCurrency as a base).
+	response, err := client.Rates.Get("NZD")
+	if err != nil {
+		t.Fatalf("Unexpected error running client.Rates.Get('NZD'): %s", err)
+	}
+
+	// Did we get a *float64 back?
+	if reflect.TypeOf(response).String() != "*float64" {
+		t.Fatalf("Unexpected rate datatype, expected float64 got %T", response)
+	}
+}
+
+// TestListRates will test updating our local store of forex rates from the OXR API.
+func TestListRates(t *testing.T) {
+	// Register the test.
+	NewWithT(t)
+
+	// Init dinero client.
+	client := NewClient(appID, "AUD", 1*time.Minute)
+
+	// Get latest forex rates.
+	response, err := client.Rates.List()
+	if err != nil {
+		if strings.HasPrefix(err.Error(), setBaseNotAllowedResponsePrefix) {
+			t.Skipf("skipping test, unsuitable app ID: %s", err)
+		}
+		t.Fatalf("Unexpected error running client.Rates.List(): %s", err)
+	}
+
+	if response.Base != "AUD" {
+		t.Fatal("Unexpected base oxr rate. Expecting `AUD`.")
+	}
+
+	if response.Rates == nil {
+		t.Fatal("Unexpected length of rates")
 	}
 }
 
 // TestGetRate will test pulling a single rate.
 func TestGetRate(t *testing.T) {
 	// Register the test.
-	RegisterTestingT(t)
+	NewWithT(t)
 
 	// Init dinero client.
-	client := NewClient(os.Getenv("OPEN_EXCHANGE_APP_ID"), "AUD", 1*time.Minute)
+	client := NewClient(appID, "AUD", 1*time.Minute)
 
 	// Get latest forex rates for NZD (using AUD as a base).
 	response, err := client.Rates.Get("NZD")
 	if err != nil {
-		t.Fatalf("Unexpected error running client.Rates.Get('NZD'): %s", err.Error())
+		if strings.HasPrefix(err.Error(), setBaseNotAllowedResponsePrefix) {
+			t.Skipf("skipping test, unsuitable app ID: %s", err)
+		}
+		t.Fatalf("Unexpected error running client.Rates.Get('NZD'): %s", err)
 	}
 
 	// Did we get a *float64 back?


### PR DESCRIPTION
- 403 Changing the API `base` currency is available for Developer, Enterprise and Unlimited plan clients.